### PR TITLE
feature: switch to a different completion preset before summarizing

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -40,6 +40,16 @@
                 <hr>
                 <h4 class="textAlignCenter">Summarization <i class="fa-solid fa-info-circle" title="Customize the prompt used to summarize a given message"></i></h4>
                 <div class="flex-container justifyspacebetween alignitemscenter">
+                    <label class="checkbox_label" title="Switch preset before summarizing">
+                        <input id="qvink_use_alternate_preset" type="checkbox" />
+                        <span>Switch preset before summarizing</span>
+                    </label>
+                    <select id="qvink_memory_completion_preset_select">
+
+                    </select>
+                </div>
+
+                <div class="flex-container justifyspacebetween alignitemscenter">
                     <button id="edit_summary_prompt" class="menu_button flex1" title="Edit the summary prompt" >Edit</button>
                     <button id="preview_summary_prompt" class="menu_button fa-solid fa-eye" title="Preview the filled-in summary prompt, using the last message as an example." ></button>
                     <button id="rerun_memory" class="menu_button fa-solid fa-rotate" title="Mass re-summarization. Brings up dialog to choose subsets of messages to summarize or re-summarize."></button>


### PR DESCRIPTION
adds a setting to let you use a different chat completion preset for summary. mostly motivated by me not wanting to eat the extra cost for summarizing with claude 3.7.
It could also be good for people using reasoning models - in my experience the summary just ends up being the \<think> section.

I've only tested it for my use case, but it seems to work okay for me. 

one issue is that closing the page while summarizing will leave the profile set to the summarize one. not sure how to work around that unless ST lets us send an override for preset when generating instead of having to switch :man_shrugging: 